### PR TITLE
Trustx sign usability enhancement (check file exists)

### DIFF
--- a/linux_example/trustx_sign.c
+++ b/linux_example/trustx_sign.c
@@ -133,37 +133,41 @@ uint16_t _writeTo(uint8_t *buf, uint32_t len, const char *filename)
 
 static uint16_t _readFrom(uint8_t *data, uint8_t *filename)
 {
-	
 	FILE *datafile;
 	uint16_t len;
 	uint8_t buf[2048];
 	uint16_t ret;
 
-	//open 
-	datafile = fopen((const char *)filename,"rb");
-	if (!datafile)
-	{
+	// check if file exists first
+	if( access((const char *)filename, F_OK ) == 0 ) {
+		// file exists open it
+		datafile = fopen((const char *)filename,"rb");
+		if (!datafile)
+		{
+			return 0;
+		}
+
+		//Read file
+		len = fread(buf, 1, sizeof(buf), datafile);
+		if (len > 0)
+		{
+			printf("Input data : \n");
+			_hexdump(buf,len);
+
+			SHA256(buf, len, data);
+
+			printf("Digest : \n");
+			_hexdump(data,32);
+			ret = 32;
+		}
+
+		fclose(datafile);
+	} else {
+		// file doesn't exist
 		return 0;
 	}
 
-	//Read file
-	len = fread(buf, 1, sizeof(buf), datafile); 
-	if (len > 0)
-	{
-		printf("Input data : \n");
-		_hexdump(buf,len);
-
-		SHA256(buf, len, data);
-
-		printf("Digest : \n");
-		_hexdump(data,32);
-		ret = 32;
-	}
-
-	fclose(datafile);
-
 	return ret;
-
 }
 
 int main (int argc, char **argv)

--- a/linux_example/trustx_sign.c
+++ b/linux_example/trustx_sign.c
@@ -143,7 +143,7 @@ static uint16_t _readFrom(uint8_t *data, uint8_t *filename)
 	datafile = fopen((const char *)filename,"rb");
 	if (!datafile)
 	{
-		return 1;
+		return 0;
 	}
 
 	//Read file


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
If a user mistypes a filename or enters a file that the user does not have access to then program execution will continue as normal and will throw an unknown error potentially confusing the user. This PR fixes a return value from 1 to 0 when fopen doesn't return a FILE which allows the program to break execution as it should. This PR also uses the access() function from  <unistd.h> which is already included. This checks to make sure that the program can access the file before opening it.

Related Issue
https://github.com/Infineon/cli-optiga-trust-x/issues/9

Context 
Experienced this problem when accidentally mistyped input filename and got an error that I could not explain.

This change was built successfully and tested.

Successful result after this change: (Note the extra w.)
```
$ trustx_sign -k 0xe0f3 -o testsignature.bin -i hellowworld.txt
========================================================
OID Key 0xE0F3
Output File Name : testsignature.bin 
Input File Name : hellowworld.txt 
Error reading file!!!
========================================================
```
